### PR TITLE
fix(types): resolve Three.js TypeScript declaration issues

### DIFF
--- a/components/home/InteractiveBuilder.tsx
+++ b/components/home/InteractiveBuilder.tsx
@@ -1,14 +1,15 @@
 'use client';
+'use client'
 
 import { useState, useRef } from 'react';
 import { motion } from 'framer-motion';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { OrbitControls, Text, Box } from '@react-three/drei';
-import * as THREE from 'three';
+import type { Mesh } from 'three';
 
 // Simple 3D component for the builder
 function TemplateElement({ position, color, onClick }: { position: [number, number, number]; color: string; onClick: () => void }) {
-  const meshRef = useRef<THREE.Mesh>(null);
+  const meshRef = useRef<Mesh>(null);
   
   useFrame((state) => {
     if (meshRef.current) {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/three": "^0.179.0",
     "autoprefixer": "^10.4.21",
     "cross-env": "^7.0.3",
     "eslint": "^9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.1.8(@types/react@19.1.12)
+      '@types/three':
+        specifier: ^0.179.0
+        version: 0.179.0
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.6)


### PR DESCRIPTION
- Add @types/three package for proper TypeScript support
- Update InteractiveBuilder component to use specific imports instead of namespace import
- Add 'use client' directive for proper client-side rendering
- Ensure compatibility with Next.js 15 and Vercel deployment

Fixes Vercel build error: 'Could not find a declaration file for module three'